### PR TITLE
Better default password for rabbitMQ

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -11,6 +11,6 @@ rabbitMQ:
     workflowCommandsExchange: commands.v1.workflow.exchange
     useSsl: true
     sslKeypassphrasePassword: keyUser
-    sslTrustpassphrasePassword: ihatejordi
+    sslTrustpassphrasePassword: iloverainbows
     sslKeypath: /certs/keycert.p12
     sslTrustpath: /certs/store


### PR DESCRIPTION
The second "addition" is just that you didn't have a newline at end of file. Not all editors add this, even though it's supposed to be there according to the POSIX standard (http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206).